### PR TITLE
Add make nuke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ auth/keycloak/config/hsperfdata_jboss/
 auth/keycloak/config/*.log
 .DS_Store
 /backups
+*.nkbak

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,15 @@ setup: ## Setup and configure local environment
 	@sh ./scripts/gen-conf.sh
 
 init: ## Initialize local environment
+	$(info Initialize local environment)
 	@make setup
 	@make up p=core
 	@make db-update
+
+nuke: ## Destroy local environment so that you can restart from scratch.
+	$(info Destroy local environment so that you can restart from scratch.)
+	@make down clean
+	@./scripts/nuke.sh
 
 .PHONY: setup
 
@@ -59,7 +65,7 @@ up: ## Runs the local container(s) (n=service name, p=profile name)
 
 down: ## Stops the local containers and removes them
 	$(info Stops the local containers and removes them)
-	@docker-compose --profile all down
+	@docker-compose --profile all down -v
 
 stop: ## Stops the local container(s) (n=service name)
 	$(info Stops the local container(s) (n=$(n)))

--- a/scripts/gen-env.sh
+++ b/scripts/gen-env.sh
@@ -99,7 +99,7 @@ echo \
 DB_USER=$varDbUser
 DB_PASSWORD=$varPassword
 
-DEFAULT_PASSWORD=$varPassword
+DEFAULT_PASSWORD=$varUserPassword
 SALT_LENGTH=50" >> ./api/libs/dal/.env
     echo -e "\t./api/libs/dal/.env created"
 fi

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+echo ""
+echo "*****************************************************"
+echo "Nuking local TNO environment and configuration"
+echo "*****************************************************"
+echo ""
+# Set the file extention used for backed up files.
+fileExt=".nkbak"
+
+# Get a list of all current environment & config files into an array.
+# Make sure that all name patterns are specified in 'find' command.
+configFiles=()
+while IFS= read -r -d $'\0'; do
+    configFiles+=("$REPLY")
+done < <(find . -type f \( -name "*.env" -o -name "connectionstrings.json" \) -print0)
+
+# Proceed only if there are 1 or more files found matching the pattern, else do nothing.
+numFiles=${#configFiles[@]}
+if [[ $numFiles > 0 ]]; then
+  echo "$numFiles configuration file(s) found."
+  echo ""
+  echo "WARNING: This operation will back-up and delete all current configuration files."
+  read -p "Enter 'y' to continue: " varContinue
+  # Continue if requested
+  if [ "$varContinue" == "y" ]; then
+    currentDT=$(date +"%Y%m%d-%H%M%S")
+    # Should we delete all existing backups before renaming current config files?
+    echo ""
+    read -p "(d/y)elete all existing backups?: " varDelete
+    if [[ "$varDelete" == "d" || "$varDelete" == "y" ]]; then
+      echo "Deleting all old configuration backups..."
+      find . -type f -name "*$fileExt" -delete
+    else
+      echo "Keeping old configuration backups."
+    fi
+
+    # For every configuration file found, move (rename) the file
+    echo ""
+    for file in "${configFiles[@]}"; do
+      echo "Moving '$file' -> '$file.$currentDT$fileExt'"
+      mv "$file" "$file.$currentDT$fileExt"
+    done
+    echo ""
+    echo "All configuration files moved.."
+  else
+    # User chose not move configuration files.
+    echo ""
+    echo "Exiting."
+  fi
+else
+  # No configuration files found to move. There is nothing to do.
+  echo "No configuration files found. Exiting."
+fi

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -6,7 +6,7 @@ then
     echo 'Enter a username for the database.'
     read -p 'Username: ' varDbUser
 else
-    echo "Your database username: $varDbUser"
+    echo "Database username: $varDbUser"
 fi
 
 varPassword=$(grep -Po 'DB_PASSWORD=\K.*$' ./db/mssql/.env)
@@ -15,9 +15,18 @@ then
   # Generate a random password that satisfies password requirements.
   echo 'A password is randomly being generated.'
   varPassword=$(date +%s | sha256sum | base64 | head -c 29)A8!
-  echo "Your generated password is: $varPassword"
+  echo "Database generated password is: $varPassword"
 else
-  echo "Your password is: $varPassword"
+  echo "Database password is: $varPassword"
+fi
+
+varUserPassword=$(grep -Po 'DEFAULT_PASSWORD=\K.*$' ./api/libs/dal/.env)
+if [ -z "$varUserPassword" ]
+then
+  echo 'Enter a password for the default admin user account.'
+  read -p 'Password: ' varUserPassword
+else
+  echo "Application admin password is: $varUserPassword"
 fi
 
 varDbName=coevent


### PR DESCRIPTION
Fix setup scripts

There is now a `make nuke` command to backup and delete configuration files.  I prefer to back things up, just in case something in them is important.

I've tested locally with a full clean and everything worked for me.